### PR TITLE
LPS 113033

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-ratings',
 	(A) => {


### PR DESCRIPTION
After some internal conversations on https://issues.liferay.com/browse/LPS-113033, there aren't any product team using this AUI component. All the occurrences of this component were replaced with [`liferay-ratings:ratings`](https://github.com/liferay/liferay-portal/tree/bc2244a90ba221bdcac72de9d58e5e8afcba88c7/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js) Taglib that is  currently implemented by React.

I'm currently adding something on https://github.com/liferay/liferay-portal/blob/master/readme/BREAKING_CHANGES.markdown file

/cc @jbalsas @ambrinchaudhary