### PR TITLE
LPS-113577 Deprecates `liferay-message` module

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/config.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/config.js
@@ -41,7 +41,6 @@
 						path: 'main.js',
 						requires: [
 							'document-library-upload',
-							'liferay-message',
 							'liferay-portlet-base',
 						],
 					},

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -567,10 +567,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: [
-			'document-library-upload',
-			'liferay-message',
-			'liferay-portlet-base',
-		],
+		requires: ['document-library-upload', 'liferay-portlet-base'],
 	}
 );

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/message.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/message.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-message',
 	(A) => {


### PR DESCRIPTION
Since this module isn't being used on Document Library, I just removed the unnecessary imports of this component from document-library-web and placed a notice about the deprecation on the module.

Established that there are no current usages by grepping:

- [`git grep '\bLiferay\.Message\b'`](https://gist.github.com/wincent/94efccb73bb591c71f0770b6409a67ad)
- [`git grep liferay-message`](https://gist.github.com/wincent/cf6db876eadbdce3f670ecba10a0ab9b)

Looks like last actual usages were removed in 54c332cdef1a8ba16cc1aa3ae0266ef6dc872bd2 ("LPS-52907 Remove Liferay sync message from Documents and Media", Jan 2015) and 82a686413063c7650c1270f7b765f48fa4549340 ("LPS-35401 Clean up js code which doesn't seem to be needed any more", May 2013).

(Found via `git log -GLiferay\.Message -p`).

/cc @jbalsas @wincent