### PR TITLE
LPS-122392 Remove {closest, contains, match} usages of metal-dom

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ColumnOverlay.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ColumnOverlay.es.js
@@ -14,7 +14,6 @@
 
 import classNames from 'classnames';
 import {useEventListener} from 'frontend-js-react-web';
-import dom from 'metal-dom';
 import React, {useContext, useLayoutEffect, useState} from 'react';
 
 import Button from '../../components/button/Button.es';
@@ -129,10 +128,7 @@ export default ({container, fields, onRemoveFieldName}) => {
 		'mouseleave',
 		({relatedTarget}) => {
 			const columnIndex = getColumnIndex(relatedTarget);
-			const outsideOverlay = !dom.closest(
-				relatedTarget,
-				'.column-overlay'
-			);
+			const outsideOverlay = !relatedTarget.closest('.column-overlay');
 
 			if (columnIndex === -1 && outsideOverlay) {
 				setHoveredFieldName(null);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/utils.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/utils.es.js
@@ -13,18 +13,17 @@
  */
 
 import {DataDefinitionUtils} from 'data-engine-taglib';
-import dom from 'metal-dom';
 
 import {addItem, updateItem} from '../../utils/client.es';
 
 export const getColumnIndex = (node) => {
-	const rowNode = dom.closest(node, 'tr');
+	const rowNode = node.closest('tr');
 
 	if (!rowNode) {
 		return -1;
 	}
 
-	const columnNode = dom.closest(node, 'td,th');
+	const columnNode = node.closest('td,th');
 
 	if (!columnNode) {
 		return -1;

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
@@ -17,7 +17,7 @@ import dom from 'metal-dom';
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
-			return !!dom.closest(target, element);
+			return !!target.closest(element);
 		}
 
 		return element && dom.contains(element, target);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
 			return !!target.closest(element);
 		}
 
-		return element && dom.contains(element, target);
+		return element && element.contains(target);
 	});
 };

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -64,7 +64,7 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 				'active'
 			);
 			dom.addClasses(
-				dom.closest(event.delegateTarget, '.form-check-card'),
+				event.delegateTarget.closest('.form-check-card'),
 				'active'
 			);
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
@@ -73,7 +73,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 	<aui:input label="exclude-assets-with-0-views" name="preferences--excludeZeroViewCount--" type="toggle-switch" value="<%= assetPublisherDisplayContext.isExcludeZeroViewCount() %>" />
 </c:if>
 
-<aui:script require="metal-dom/src/dom as dom">
+<aui:script>
 	var displayStyleSelect = document.getElementById(
 		'<portlet:namespace />displayStyle'
 	);
@@ -84,7 +84,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 		var hiddenFields = document.querySelectorAll('.hidden-field');
 
 		Array.prototype.forEach.call(hiddenFields, function (field) {
-			var fieldContainer = dom.closest(field, '.form-group');
+			var fieldContainer = field.closest('.form-group');
 
 			if (fieldContainer) {
 				var fieldClassList = field.classList;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
@@ -17,7 +17,7 @@ import dom from 'metal-dom';
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
-			return !!dom.closest(target, element);
+			return !!target.closest(element);
 		}
 
 		return element && dom.contains(element, target);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/utils/clickOutside.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 export default (target, ...elements) => {
 	return !elements.some((element) => {
 		if (typeof element === 'string') {
 			return !!target.closest(element);
 		}
 
-		return element && dom.contains(element, target);
+		return element && element.contains(target);
 	});
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
@@ -167,7 +167,7 @@ const withActionableFields = (ChildComponent) => {
 		}
 
 		_getClosestParent(node) {
-			return dom.closest(node.parentElement, `.ddm-field-container`);
+			return node.parentElement.closest('.ddm-field-container');
 		}
 
 		_getHoveredNode() {
@@ -183,8 +183,7 @@ const withActionableFields = (ChildComponent) => {
 			const {fieldName} = delegateTarget.dataset;
 			const {hoveredFieldActions, selectedFieldActions} = this.refs;
 			const activePage = parseInt(
-				dom.closest(event.delegateTarget, '[data-ddm-page]').dataset
-					.ddmPage,
+				event.delegateTarget.closest('[data-ddm-page]').dataset.ddmPage,
 				10
 			);
 			this.setState({activePage});
@@ -294,8 +293,7 @@ const withActionableFields = (ChildComponent) => {
 		}
 
 		_hasLeftField(relatedTarget) {
-			return !dom.closest(
-				relatedTarget,
+			return !relatedTarget.closest(
 				'.dropdown-menu,.ddm-field-actions-container'
 			);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withClickableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withClickableFields.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 
@@ -51,7 +50,7 @@ const withClickableFields = (ChildComponent) => {
 				!event.delegateTarget.children[1].hasAttribute('aria-grabbed')
 			) {
 				activePage = parseInt(
-					dom.closest(event.delegateTarget, '[data-ddm-page]').dataset
+					event.delegateTarget.closest('[data-ddm-page]').dataset
 						.ddmPage,
 					10
 				);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMoveableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMoveableFields.es.js
@@ -13,7 +13,6 @@
  */
 
 import {FormSupport} from 'dynamic-data-mapping-form-renderer';
-import dom from 'metal-dom';
 import {DragDrop} from 'metal-drag-drop';
 import Component from 'metal-jsx';
 
@@ -80,7 +79,7 @@ const withMoveableFields = (ChildComponent) => {
 		}
 
 		_getClosestParent(node) {
-			return dom.closest(node.parentElement, `.ddm-field-container`);
+			return node.parentElement.closest('.ddm-field-container');
 		}
 
 		_handleDragAndDropEnd({source, target}) {
@@ -98,13 +97,10 @@ const withMoveableFields = (ChildComponent) => {
 			}
 
 			if (target) {
-				const sourceFieldNode = dom.closest(
-					source,
-					'.ddm-field-container'
-				);
+				const sourceFieldNode = source.closest('.ddm-field-container');
 
 				const sourceFieldPage = parseInt(
-					dom.closest(source, '[data-ddm-page]').dataset.ddmPage,
+					source.closest('[data-ddm-page]').dataset.ddmPage,
 					10
 				);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
 import Component from 'metal-jsx';
 
@@ -85,7 +84,7 @@ const withResizeableColumns = (ChildComponent) => {
 			const {store} = this.context;
 
 			if (!this._currentRow) {
-				this._currentRow = dom.closest(source, '.row');
+				this._currentRow = source.closest('.row');
 			}
 
 			const container = this._currentRow.querySelector(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es.js
@@ -24,7 +24,6 @@ import 'dynamic-data-mapping-form-renderer/js/components/Field/ReactFieldAdapter
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
 import {makeFetch} from 'dynamic-data-mapping-form-renderer/js/util/fetch.es';
 import Component from 'metal-component';
-import dom from 'metal-dom';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
 
@@ -660,7 +659,7 @@ class RuleEditor extends Component {
 	}
 
 	_getIndex(fieldInstance, fieldClass) {
-		const firstOperand = dom.closest(fieldInstance.element, fieldClass);
+		const firstOperand = fieldInstance.element.closest(fieldClass);
 
 		return firstOperand.getAttribute(`${fieldClass.substring(1)}-index`);
 	}
@@ -1044,7 +1043,7 @@ class RuleEditor extends Component {
 
 		let index;
 
-		if (dom.closest(fieldInstance.element, '.condition-type-value')) {
+		if (fieldInstance.element.closest('.condition-type-value')) {
 			index = this._getIndex(fieldInstance, '.condition-type-value');
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleList/RuleList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleList/RuleList.es.js
@@ -286,7 +286,7 @@ class RuleList extends Component {
 	}
 
 	_handleDocumentMouseUp({target}) {
-		const dropdownSettings = dom.closest(target, '.ddm-rule-list-settings');
+		const dropdownSettings = target.closest('.ddm-rule-list-settings');
 
 		if (dropdownSettings) {
 			return;
@@ -301,7 +301,7 @@ class RuleList extends Component {
 		event.preventDefault();
 
 		const {dropdownExpandedIndex} = this;
-		const ruleNode = dom.closest(event.delegateTarget, '.component-action');
+		const ruleNode = event.delegateTarget.closest('.component-action');
 
 		let ruleIndex = parseInt(ruleNode.dataset.ruleIndex, 10);
 
@@ -315,7 +315,7 @@ class RuleList extends Component {
 	}
 
 	_handleRuleCardClicked({data, target}) {
-		const cardElement = dom.closest(target.element, '[data-card-id]');
+		const cardElement = target.element.closest('[data-card-id]');
 		const cardId = parseInt(cardElement.getAttribute('data-card-id'), 10);
 
 		if (data.item.settingsItem == 'edit') {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -575,7 +575,7 @@ class Sidebar extends Component {
 
 		const {fieldTypes} = this.props;
 		const {fieldSetId} = data.source.dataset;
-		const columnNode = dom.closest(data.target, '.col-ddm');
+		const columnNode = data.target.closest('.col-ddm');
 		const indexes = FormSupport.getIndexes(columnNode);
 
 		if (fieldSetId) {
@@ -593,8 +593,7 @@ class Sidebar extends Component {
 				return name === data.source.dataset.fieldTypeName;
 			});
 			let parentFieldName;
-			const parentFieldNode = dom.closest(
-				data.target.parentElement,
+			const parentFieldNode = data.target.parentElement.closest(
 				'.ddm-field'
 			);
 
@@ -615,11 +614,8 @@ class Sidebar extends Component {
 				indexes,
 			};
 
-			if (dom.closest(data.target, '.col-empty')) {
-				const addedToPlaceholder = dom.closest(
-					data.target,
-					'.placeholder'
-				);
+			if (data.target.closest(data.target, '.col-empty')) {
+				const addedToPlaceholder = data.target.closest('.placeholder');
 
 				dispatch('fieldAdded', {
 					...payload,
@@ -639,9 +635,8 @@ class Sidebar extends Component {
 	}
 
 	_handleDragTargetEnter({target}) {
-		const parentFieldNode = dom.closest(
-			target.parentElement,
-			`.ddm-field-container`
+		const parentFieldNode = target.parentElement.closest(
+			'.ddm-field-container'
 		);
 
 		if (parentFieldNode) {
@@ -650,9 +645,8 @@ class Sidebar extends Component {
 	}
 
 	_handleDragTargetLeave({target}) {
-		const parentFieldNode = dom.closest(
-			target.parentElement,
-			`.ddm-field-container`
+		const parentFieldNode = target.parentElement.closest(
+			'.ddm-field-container'
 		);
 
 		if (parentFieldNode) {
@@ -763,7 +757,7 @@ class Sidebar extends Component {
 		const {target} = event;
 		const {
 			dataset: {index},
-		} = dom.closest(target, '.nav-item');
+		} = target.closest('.nav-item');
 
 		event.preventDefault();
 
@@ -779,7 +773,7 @@ class Sidebar extends Component {
 	}
 
 	_isControlProductMenuItem(node) {
-		return !!dom.closest(node, '.sidenav-toggler');
+		return !!node.closest('.sidenav-toggler');
 	}
 
 	_isEditMode() {
@@ -789,15 +783,15 @@ class Sidebar extends Component {
 	}
 
 	_isModalElement(node) {
-		return dom.closest(node, '.modal');
+		return node.closest('.modal');
 	}
 
 	_isProductMenuSidebarItem(node) {
-		return !!dom.closest(node, '.sidenav-menu');
+		return !!node.closest('.sidenav-menu');
 	}
 
 	_isOutsideModal(node) {
-		return !dom.closest(node, '.close-modal');
+		return !node.closest('.close-modal');
 	}
 
 	_isSettingsElement(target) {
@@ -816,9 +810,9 @@ class Sidebar extends Component {
 
 	_isSidebarElement(node) {
 		const {element} = this;
-		const alloyEditorToolbarNode = dom.closest(node, '.ae-ui');
-		const fieldColumnNode = dom.closest(node, '.col-ddm');
-		const fieldTypesDropdownNode = dom.closest(node, '.dropdown-menu');
+		const alloyEditorToolbarNode = node.closest('.ae-ui');
+		const fieldColumnNode = node.closest('.col-ddm');
+		const fieldTypesDropdownNode = node.closest('.dropdown-menu');
 
 		return (
 			alloyEditorToolbarNode ||
@@ -830,7 +824,7 @@ class Sidebar extends Component {
 	}
 
 	_isTranslationItem(node) {
-		return !!dom.closest(node, '.lfr-translationmanager');
+		return !!node.closest('.lfr-translationmanager');
 	}
 
 	_mergeFieldTypeSettings(oldSettingsContext, newSettingsContext) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/util/dragAndDrop.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/util/dragAndDrop.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
 import {getField, isFieldSet, isFieldSetChild} from './fieldSupport.es';
 
 export const disableFieldDropTargets = (element) => {
@@ -22,7 +20,7 @@ export const disableFieldDropTargets = (element) => {
 	for (let i = 0; i < dropTargets.length; i++) {
 		const target = dropTargets[i];
 
-		const parentFieldNode = dom.closest(target, '.ddm-field-container');
+		const parentFieldNode = target.closest('.ddm-field-container');
 
 		if (parentFieldNode) {
 			target.setAttribute('data-drop-disabled', true);
@@ -50,7 +48,7 @@ export const disableFieldSetDropTargets = (element, pages) => {
 	for (let i = 0; i < dropTargets.length; i++) {
 		const target = dropTargets[i];
 
-		const parentFieldNode = dom.closest(target, '.ddm-field-container');
+		const parentFieldNode = target.closest('.ddm-field-container');
 
 		if (parentFieldNode) {
 			const {fieldName} = parentFieldNode.dataset;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/formId.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/formId.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import dom from 'metal-dom';
-
-export const getFormNode = (element) => dom.closest(element, 'form');
+export const getFormNode = (element) => element.closest('form');
 
 export const getFormId = (form) => form?.dataset.ddmforminstanceid;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -83,7 +83,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 		'click',
 		'li',
 		function (event) {
-			var navItem = dom.closest(event.delegateTarget, '.nav-item');
+			var navItem = event.delegateTarget.closest('.nav-item');
 			var navItemIndex = Number(navItem.dataset.navItemIndex);
 			var navLink = navItem.querySelector('.nav-link');
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -726,7 +726,7 @@ class Form extends Component {
 
 	_handleFormNavClicked(event) {
 		const {delegateTarget} = event;
-		const navItem = dom.closest(delegateTarget, '.nav-item');
+		const navItem = delegateTarget.closest('.nav-item');
 		const navItemIndex = Number(navItem.dataset.navItemIndex);
 		const navLink = navItem.querySelector('.nav-link');
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -17,7 +17,6 @@ import './ImageEditorLoading.es';
 import 'clay-dropdown';
 import {PortletBase} from 'frontend-js-web';
 import {async, core} from 'metal';
-import dom from 'metal-dom';
 import Soy from 'metal-soy';
 
 import templates from './ImageEditor.soy';
@@ -451,7 +450,7 @@ class ImageEditor extends PortletBase {
 
 		const canvas = this.getImageEditorCanvas();
 
-		const boundingBox = dom.closest(this.element, '.portlet-layout');
+		const boundingBox = this.element.closest('.portlet-layout');
 		const availableWidth = boundingBox.offsetWidth;
 
 		let dialogFooterHeight = 0;

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
@@ -25,7 +25,7 @@ export default () => {
 			(event) => {
 				event.preventDefault();
 
-				const container = dom.closest(event.delegateTarget, '.alert');
+				const container = event.delegateTarget.closest('.alert');
 
 				if (container) {
 					container.parentNode.removeChild(container);

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -154,7 +154,7 @@ class LiferayApp extends App {
 
 			return Array.prototype.slice
 				.call(portlets)
-				.some((portlet) => dom.contains(portlet, element));
+				.some((portlet) => portlet.contains(element));
 		});
 	}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -15,7 +15,6 @@
 'use strict';
 
 import {async} from 'metal';
-import {match} from 'metal-dom';
 import {utils, version} from 'senna';
 import globals from 'senna/lib/globals/globals';
 
@@ -94,7 +93,7 @@ const initSPA = function () {
 			const url = formElement.action;
 
 			if (
-				match(formElement, formSelector) &&
+				formElement.matches(formSelector) &&
 				app.canNavigate(url) &&
 				formElement.method !== 'get' &&
 				!app.isInPortletBlacklist(formElement)
@@ -106,7 +105,7 @@ const initSPA = function () {
 				const buttonSelector =
 					'button:not([type]),button[type=submit],input[type=submit]';
 
-				if (match(globals.document.activeElement, buttonSelector)) {
+				if (globals.document.activeElement.matches(buttonSelector)) {
 					globals.capturedFormButtonElement =
 						globals.document.activeElement;
 				}

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -226,7 +226,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 						'active'
 					);
 					dom.addClasses(
-						dom.closest(event.delegateTarget, '.form-check-card'),
+						event.delegateTarget.closest('.form-check-card'),
 						'active'
 					);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -386,7 +386,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 						'active'
 					);
 					dom.addClasses(
-						dom.closest(event.delegateTarget, '.form-check-card'),
+						event.delegateTarget.closest('.form-check-card'),
 						'active'
 					);
 				</c:when>
@@ -395,10 +395,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 						document.querySelectorAll('.articles.active'),
 						'active'
 					);
-					dom.addClasses(
-						dom.closest(event.delegateTarget, '.articles'),
-						'active'
-					);
+					dom.addClasses(event.delegateTarget.closest('.articles'), 'active');
 				</c:otherwise>
 			</c:choose>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
@@ -55,7 +55,7 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 				'active'
 			);
 			dom.addClasses(
-				dom.closest(event.delegateTarget, '.form-check-card'),
+				event.delegateTarget.closest('.form-check-card'),
 				'active'
 			);
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -69,7 +69,7 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 				'active'
 			);
 			dom.addClasses(
-				dom.closest(event.delegateTarget, '.form-check-card'),
+				event.delegateTarget.closest('.form-check-card'),
 				'active'
 			);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
@@ -14,7 +14,6 @@
 
 import ClayPopover from '@clayui/popover';
 import {useEventListener} from 'frontend-js-react-web';
-import {match} from 'metal-dom';
 import {Align} from 'metal-position';
 import React, {
 	useCallback,
@@ -76,7 +75,7 @@ const DisabledArea = () => {
 				!hasAbsolutePosition &&
 				!DEFAULT_WHITELIST.some(
 					(selector) =>
-						match(element, selector) ||
+						element.matches(selector) ||
 						element.querySelector(selector)
 				)
 			);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Layout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Layout.js
@@ -15,7 +15,6 @@
 import ClayAlert from '@clayui/alert';
 import classNames from 'classnames';
 import {useIsMounted} from 'frontend-js-react-web';
-import {closest} from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
@@ -75,7 +74,7 @@ export default function Layout({mainItemId}) {
 		const layout = layoutRef.current;
 
 		const preventLinkClick = (event) => {
-			const closestElement = closest(event.target, '[href]');
+			const closestElement = event.target.closest('[href]');
 
 			if (
 				closestElement &&

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MasterLayout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MasterLayout.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {closest} from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef} from 'react';
 
@@ -119,11 +118,11 @@ function Fragment({item}) {
 		const handler = (event) => {
 			const element = event.target;
 
-			if (closest(element, '[href]')) {
+			if (element.closest('[href]')) {
 				event.preventDefault();
 			}
 
-			if (!closest(event.target, '.page-editor')) {
+			if (!event.target.closest('.page-editor')) {
 				selectItem(null);
 			}
 		};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {closest} from 'metal-dom';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {
@@ -41,13 +40,13 @@ const ctrlOrMeta = (event) =>
 	(event.ctrlKey && !event.metaKey) || (!event.ctrlKey && event.metaKey);
 
 const isEditableField = (element) =>
-	!!closest(element, '.page-editor__editable');
+	!!element.closest('.page-editor__editable');
 
 const isInteractiveElement = (element) => {
 	return (
 		['INPUT', 'OPTION', 'SELECT', 'TEXTAREA'].includes(element.tagName) ||
-		!!closest(element, '.cke_editable') ||
-		!!closest(element, '.alloy-editor-container')
+		!!element.closest('.cke_editable') ||
+		!!element.closest('.alloy-editor-container')
 	);
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/getEditableElement.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/getEditableElement.js
@@ -12,17 +12,15 @@
  * details.
  */
 
-import {closest} from 'metal-dom';
-
 export function getEditableElement(target) {
-	let editableElement = closest(target, 'lfr-editable');
+	let editableElement = target.closest('lfr-editable');
 
 	if (!editableElement) {
-		editableElement = closest(target, '[data-lfr-editable-id]');
+		editableElement = target.closest('[data-lfr-editable-id]');
 	}
 
 	if (!editableElement) {
-		editableElement = closest(target, '[data-lfr-background-image-id]');
+		editableElement = target.closest('[data-lfr-background-image-id]');
 	}
 
 	return editableElement;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -119,7 +119,7 @@ Hits hits = searchDisplayContext.getHits();
 			if (!target.classList.contains('active')) {
 				target.classList.add('active');
 
-				var searchFacet = dom.closest(target, '.search-facet');
+				var searchFacet = target.closest('.search-facet');
 
 				var facetValueSiblings = Array.prototype.filter.call(
 					target.parentNode.children,

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTreeEventHandler.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTreeEventHandler.es.js
@@ -13,7 +13,6 @@
  */
 
 import Component from 'metal-component';
-import dom from 'metal-dom';
 
 class PagesTreeEventHandler extends Component {
 	attached() {
@@ -25,9 +24,9 @@ class PagesTreeEventHandler extends Component {
 	}
 
 	_handleDropdownOpened({menu, trigger}) {
-		if (dom.closest(menu, '.pages-tree-dropdown')) {
+		if (menu.closest('.pages-tree-dropdown')) {
 			const handler = (event) => {
-				if (!dom.closest(event.target, '.pages-tree-dropdown')) {
+				if (!event.target.closest('.pages-tree-dropdown')) {
 					Liferay.DropdownProvider.hide({menu, trigger});
 
 					window.removeEventListener('click', handler);

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -177,7 +177,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 	);
 
 	dom.delegate(document, 'click', '.assign-site-roles-link', function (event) {
-		var link = dom.closest(event.target, '.assign-site-roles-link');
+		var link = event.target.closest('.assign-site-roles-link');
 
 		var itemSelectorURL = link.dataset.itemselectorurl;
 		var segmentsEntryId = link.dataset.segmentsentryid;

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
@@ -22,7 +22,6 @@ import ClaySticker from '@clayui/sticker';
 import classNames from 'classnames';
 import {useTimeout} from 'frontend-js-react-web';
 import {fetch, objectToFormData} from 'frontend-js-web';
-import dom from 'metal-dom';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -119,8 +118,7 @@ const ManageCollaborators = ({
 		if (
 			invalidElements.indexOf(eventTarget.nodeName.toLowerCase()) === -1
 		) {
-			const collaboratorContainer = dom.closest(
-				eventTarget,
+			const collaboratorContainer = eventTarget.closest(
 				'.list-group-item'
 			);
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuItemDOMHandler.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuItemDOMHandler.js
@@ -14,7 +14,6 @@
 
 import {
 	addClasses,
-	closest,
 	contains,
 	hasClass,
 	next,
@@ -54,7 +53,7 @@ const getChildren = function (menuItem) {
  * @return {HTMLElement|null}
  */
 const getFromContentElement = function (menuItemContent) {
-	return closest(menuItemContent, `.${MENU_ITEM_CLASSNAME}`);
+	return menuItemContent.closest(`.${MENU_ITEM_CLASSNAME}`);
 };
 
 /**

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -78,7 +78,7 @@
 		'focusin',
 		'.portlet',
 		function(event) {
-			dom.addClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+			dom.addClasses(event.delegateTarget.closest('.portlet'), 'open');
 		}
 	);
 
@@ -87,7 +87,7 @@
 		'focusout',
 		'.portlet',
 		function(event) {
-			dom.removeClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+			dom.removeClasses(event.delegateTarget.closest('.portlet'), 'open');
 		}
 	);
 </aui:script>


### PR DESCRIPTION
## Found usages by grepping: 

* `git grep "contains(" -- '*.js*'`

* `git grep "closest(" -- '*.js*'`

* `git grep "match(" -- '*.js*'`

and replaced 

[domNamed contains](https://github.com/metal/metal.js/blob/466812085dd29e37c90b835c64cb49555d76a294/packages/metal-dom/src/domNamed.js#L218..L225) with native [contains](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains)

[domNamed closest](https://github.com/metal/metal.js/blob/466812085dd29e37c90b835c64cb49555d76a294/packages/metal-dom/src/domNamed.js#L163..L167) with native [closest](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest).

[domNamed match](https://github.com/metal/metal.js/blob/466812085dd29e37c90b835c64cb49555d76a294/packages/metal-dom/src/domNamed.js#L418) with [matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)

## Test Case:

contains/closest when using [clickOutside.es.js](https://github.com/diegonvs/liferay-portal/blob/9e150a71e252c3eee2b5c2739d2858085f6e62c3/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/utils/clickOutside.es.js)

1. Global Menu -> Applications -> App Builder -> Objects
2. Click on plus button for creating a new custom object and then click outside the panel to close it

matches

TDB

## Questions

Considering the previous PR, I blacklisted(to not be touched) the following modules:

`frontend-image-editor`

`site-navigation-admin-web`

[I notice We have the same implementation of clickOutside related things everywhere](https://gist.github.com/diegonvs/81678850b2f02d9f9e0d60418d350b81). Should We consider creating a utility for that?

As a suggestion, on React-side We can create a util like [this one](https://elastic.github.io/eui/#/utilities/outside-click-detector) and may leave a pure-js implementation too.