### PR TITLE
Remove thrown error in catch

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/submitEmailContent.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/submitEmailContent.es.js
@@ -61,7 +61,5 @@ export function submitEmailContent({
 						message: response.errorMessage,
 				  });
 		})
-		.catch((error) => {
-			throw new Error(error);
-		});
+		.catch(() => {});
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/ShareFormModal.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/ShareFormModal.js
@@ -149,7 +149,7 @@ describe('ShareFormModal', () => {
 		expect(spy.mock.calls[0][0]).toBe(props.autocompleteUserURL);
 	});
 
-	it.skip('when filling the email addresses and creating a subject, sends the email with the proper payload and endpoint', async () => {
+	it('when filling the email addresses and creating a subject, sends the email with the proper payload and endpoint', async () => {
 		fetch.mockResponse(JSON.stringify([]));
 
 		const CUSTOM_MESSAGE = 'my custom message';


### PR DESCRIPTION
Hey Diego, I got a chance to look into those failing tests that we ended up skipping and I realized that if we remove the `throw new Error(error);` that it starts to work fine again. I don't see examples of us intentionally throwing errors like this in DXP at all and think it would be safe to remove. What do you think? Did you notice any issues with this?

This is the original error:
```
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "Error: TypeError: window.Liferay.component is not a function".] {
  code: 'ERR_UNHANDLED_REJECTION'
```